### PR TITLE
Fixed  lock count collect

### DIFF
--- a/bin/metric-postgres-locks.rb
+++ b/bin/metric-postgres-locks.rb
@@ -83,15 +83,15 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
                          password: config[:password],
                          connect_timeout: config[:timeout])
     request = [
-      'SELECT mode, count(mode) FROM pg_locks',
-      "where database = (select oid from pg_database where datname = '#{config[:database]}')",
-      'group by mode'
+      'SELECT mode, count(mode) AS count FROM pg_locks',
+      "WHERE database = (SELECT oid FROM pg_database WHERE datname = '#{config[:database]}')",
+      'GROUP BY mode'
     ]
 
     con.exec(request.join(' ')) do |result|
       result.each do |row|
         lock_name = row['mode'].downcase.to_sym
-        locks_per_type[lock_name] += 1
+        locks_per_type[lock_name] = row['count']
       end
     end
 


### PR DESCRIPTION
I found bug on your source.
You do not need to plus 1 when  while syntax after add "group by"
If you want get correct number need use count

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

